### PR TITLE
Remove asyncio

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -23,7 +23,7 @@ setuptools.setup(
         "Programming Language :: Python :: Implementation :: CPython",
     ],
     packages=setuptools.find_packages(),
-    install_requires=["bleak>=0.20.2", "asyncio>=3.4.3"],
+    install_requires=["bleak>=0.20.2"],
     package_data={
         "license": ["LICENSE"],
     },


### PR DESCRIPTION
`asyncio` is a [standard library](https://docs.python.org/3.9/library/asyncio.html).